### PR TITLE
Fixed Synatx so it compiles on Visual Studio 2013, too

### DIFF
--- a/ArxOne.Ftp/FtpClient.cs
+++ b/ArxOne.Ftp/FtpClient.cs
@@ -88,7 +88,15 @@ namespace ArxOne.Ftp
         /// <value>
         /// The server features.
         /// </value>
-        public FtpServerFeatures ServerFeatures => GetServerFeatures(null);
+        public FtpServerFeatures ServerFeatures
+        {
+            get
+            {
+                return this.GetServerFeatures(null);
+            }
+        }
+
+
 
         /// <summary>
         /// Gets or sets the default encoding.
@@ -135,7 +143,13 @@ namespace ArxOne.Ftp
         /// Gets the system.
         /// </summary>
         /// <value>The system.</value>
-        public string System => GetSystem(null);
+        public string System
+        {
+            get
+            {
+                return this.GetSystem(null);
+            }
+        }
 
         /// <summary>
         /// Gets the system.
@@ -152,6 +166,7 @@ namespace ArxOne.Ftp
             return _system;
         }
 
+
         private FtpServerType? _serverType;
         /// <summary>
         /// Gets the type of the server.
@@ -159,7 +174,15 @@ namespace ArxOne.Ftp
         /// <value>
         /// The type of the server.
         /// </value>
-        public FtpServerType ServerType => GetServerType(null);
+        public FtpServerType ServerType
+        {
+            get
+            {
+                return this.GetServerType(null);
+            }
+        }
+
+
 
         /// <summary>
         /// Gets the type of the server.
@@ -189,7 +212,13 @@ namespace ArxOne.Ftp
         /// <value>
         /// The FTP platform.
         /// </value>
-        public FtpPlatform Platform => GetPlatform(null);
+        public FtpPlatform Platform
+        {
+            get
+            {
+                return this.GetPlatform(null);
+            }
+        }
 
         /// <summary>
         /// Gets the platform.
@@ -209,7 +238,16 @@ namespace ArxOne.Ftp
         /// <value>
         /// The host address.
         /// </value>
-        internal IPAddress HostAddress => ActiveTransferHost ?? ActualActiveTransferHost;
+        internal IPAddress HostAddress
+        {
+            get
+            {
+                return this.ActiveTransferHost ?? this.ActualActiveTransferHost;
+            }
+        }
+
+
+
 
         /// <summary>
         /// Gets or sets the actual active transfer host.
@@ -351,7 +389,7 @@ namespace ArxOne.Ftp
                 case FtpServerType.Windows:
                     return new WindowsFtpPlatform();
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(serverType), serverType, null);
+                    throw new ArgumentOutOfRangeException("serverType", serverType, null);
             }
         }
 
@@ -439,7 +477,7 @@ namespace ArxOne.Ftp
                 case FtpProtocol.FtpES:
                     return "ftpes";
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(protocol));
+                    throw new ArgumentOutOfRangeException("protocol");
             }
         }
 
@@ -610,7 +648,7 @@ namespace ArxOne.Ftp
         {
             try
             {
-                for (;;)
+                for (; ; )
                 {
                     Thread.Sleep(SessionTimeout);
                     CleanupConnections();

--- a/ArxOne.Ftp/FtpClientParameters.cs
+++ b/ArxOne.Ftp/FtpClientParameters.cs
@@ -13,22 +13,54 @@ namespace ArxOne.Ftp
     using System.Security.Cryptography.X509Certificates;
     using System.Text;
 
+
     /// <summary>
     /// Parameters to initialize FtpClient instance
     /// </summary>
     public class FtpClientParameters
     {
+
+
+        private TimeSpan m_connectTimeout = TimeSpan.FromSeconds(10);
+
         /// <summary>
         /// Gets or sets the connect timeout.
         /// </summary>
         /// <value>The connect timeout.</value>
-        public TimeSpan ConnectTimeout { get; set; } = TimeSpan.FromSeconds(10);
+        public TimeSpan ConnectTimeout
+        {
+            get
+            {
+                return this.m_connectTimeout;
+            }
+            set
+            {
+                this.m_connectTimeout = value;
+            }
+        }
+
+
+        private TimeSpan m_readWriteTimeout = TimeSpan.FromMinutes(10);
 
         /// <summary>
         /// Gets or sets the read write timeout.
         /// </summary>
         /// <value>The read write timeout.</value>
-        public TimeSpan ReadWriteTimeout { get; set; } = TimeSpan.FromMinutes(10);
+        public TimeSpan ReadWriteTimeout
+        {
+            get
+            {
+                return this.m_readWriteTimeout;
+            }
+            set
+            {
+                this.m_readWriteTimeout = value;
+            }
+        }
+
+
+
+        private TimeSpan m_sessionTimeout = TimeSpan.FromMinutes(2);
 
         /// <summary>
         /// Gets or sets the session timeout.
@@ -36,13 +68,41 @@ namespace ArxOne.Ftp
         /// <value>
         /// The session timeout.
         /// </value>
-        public TimeSpan SessionTimeout { get; set; } = TimeSpan.FromMinutes(2);
+
+        public TimeSpan SessionTimeout
+        {
+            get
+            {
+                return this.m_sessionTimeout;
+            }
+            set
+            {
+                this.m_sessionTimeout = value;
+            }
+        }
+
+
+
+        private bool m_passive = true;
 
         /// <summary>
         /// Gets or sets a value indicating whether this <see cref="FtpClientParameters"/> is passive.
         /// </summary>
         /// <value><c>true</c> if passive; otherwise, <c>false</c>.</value>
-        public bool Passive { get; set; } = true;
+        public bool Passive
+        {
+            get
+            {
+                return this.m_passive;
+            }
+            set
+            {
+                this.m_passive = value;
+            }
+        }
+
+
+
 
         /// <summary>
         /// Gets or sets the active transfer host.
@@ -53,17 +113,47 @@ namespace ArxOne.Ftp
         /// </value>
         public IPAddress ActiveTransferHost { get; set; }
 
+
+
+        private string m_anonymousPassword = "user@" + Environment.MachineName;
+
         /// <summary>
         /// Gets or sets the anonymous password.
         /// </summary>
         /// <value>The anonymous password.</value>
-        public string AnonymousPassword { get; set; } = "user@" + Environment.MachineName;
+        public string AnonymousPassword
+        {
+            get
+            {
+                return this.m_anonymousPassword;
+            }
+            set
+            {
+                this.m_anonymousPassword = value;
+            }
+        }
+
+
+
+        private System.Text.Encoding m_defaultEncoding = System.Text.Encoding.UTF8;
 
         /// <summary>
         /// Gets or sets the default encoding.
         /// </summary>
         /// <value>The default encoding.</value>
-        public Encoding DefaultEncoding { get; set; } = Encoding.UTF8;
+        public System.Text.Encoding DefaultEncoding
+        {
+            get
+            {
+                return this.m_defaultEncoding;
+            }
+            set
+            {
+                this.m_defaultEncoding = value;
+            }
+        }
+
+
 
         /// <summary>
         /// Gets or sets the proxy connector.
@@ -100,4 +190,6 @@ namespace ArxOne.Ftp
         /// </value>
         public X509CertificateCollection ClientCertificates { get; set; }
     }
+
+
 }

--- a/ArxOne.Ftp/FtpSession.cs
+++ b/ArxOne.Ftp/FtpSession.cs
@@ -24,11 +24,22 @@ namespace ArxOne.Ftp
     /// </summary>
     public class FtpSession : IDisposable
     {
+
+        private FtpConnection m_connection;
+
         /// <summary>
         /// Gets or sets the FTP session.
         /// </summary>
         /// <value>The FTP session.</value>
-        public FtpConnection Connection { get; }
+        public FtpConnection Connection
+        {
+            get
+            {
+                return this.m_connection;
+            }
+        }
+
+
 
         /// <summary>
         /// Gets the transport stream.
@@ -88,7 +99,8 @@ namespace ArxOne.Ftp
         /// <param name="connection">The FTP session.</param>
         internal FtpSession(FtpConnection connection)
         {
-            Connection = connection;
+            this.m_connection = connection;
+            
             Connection.AddReference();
         }
 
@@ -495,7 +507,7 @@ namespace ArxOne.Ftp
         {
             var reply = new FtpReply();
             {
-                for (;;)
+                for (; ; )
                 {
                     var line = ReadLine(() => ReadByte(stream));
                     if (line == null)
@@ -550,7 +562,7 @@ namespace ArxOne.Ftp
             var eolB = EolB;
             var index = 0;
             var buffer = _readLineBuffer;
-            for (;;)
+            for (; ; )
             {
                 var b = byteReader();
                 if (b == -1)

--- a/ArxOne.Ftp/Properties/AssemblyInfo.cs
+++ b/ArxOne.Ftp/Properties/AssemblyInfo.cs
@@ -21,7 +21,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
 
-[assembly: AssemblyVersion("1.10")]
+
 
 [assembly: CLSCompliant(true)]
 
@@ -31,3 +31,7 @@ using System.Runtime.CompilerServices;
 + "d4f69c1b9a25c4cee5e1f0ec53e985b2c421c5f7e3e6b28bcdce010fd58e777f09161cded4e5af"
 + "64859d80b241d3cd234de6e9ea396561e7e0f95c76805f0db0fc582a9fac0f890f80a91f7a189b"
 + "38826cb9")]
+
+
+[assembly: AssemblyVersion("2016.12.6.1431")]
+[assembly: AssemblyFileVersion("2016.12.6.1431")]

--- a/ArxOne.Ftp/Properties/AssemblyInfo.cs
+++ b/ArxOne.Ftp/Properties/AssemblyInfo.cs
@@ -21,7 +21,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
 
-
+[assembly: AssemblyVersion("1.10")]
+[assembly: AssemblyFileVersion("1.10")]
 
 [assembly: CLSCompliant(true)]
 
@@ -31,7 +32,3 @@ using System.Runtime.CompilerServices;
 + "d4f69c1b9a25c4cee5e1f0ec53e985b2c421c5f7e3e6b28bcdce010fd58e777f09161cded4e5af"
 + "64859d80b241d3cd234de6e9ea396561e7e0f95c76805f0db0fc582a9fac0f890f80a91f7a189b"
 + "38826cb9")]
-
-
-[assembly: AssemblyVersion("2016.12.6.1431")]
-[assembly: AssemblyFileVersion("2016.12.6.1431")]


### PR DESCRIPTION
If you'd kindly accept this pull-request, people who are still on Visual Studio 2013 will have no more problems compiling ArxOne.