### PR TITLE
Fix anonymous authorization without password

### DIFF
--- a/ArxOne.Ftp/FtpSession.cs
+++ b/ArxOne.Ftp/FtpSession.cs
@@ -329,9 +329,12 @@ namespace ArxOne.Ftp
             var userResult = Expect(SendCommand(ProtocolStream, "USER", credential.UserName), 230, 331, 530);
             if (userResult.Code == 530)
                 throw new FtpAuthenticationException("No anonymous user allowed", userResult.Code);
-            var passResult = SendCommand(ProtocolStream, "PASS", credential.Password);
-            if (passResult.Code != 230)
+            if (userResult.Code != 230)
+            {
+              var passResult = SendCommand(ProtocolStream, "PASS", credential.Password);
+              if (passResult.Code != 230)
                 throw new FtpAuthenticationException("Authentication failed for user " + credential.UserName, passResult.Code);
+            }
 
             Connection.Client.OnConnectionInitialized();
         }


### PR DESCRIPTION
Servers do not require a password in the request for anonymous users. If the authorization is successful, the PASS command is not sent.