### PR TITLE
212 (Directory status) is a valid STAT return code

### DIFF
--- a/ArxOne.Ftp/FtpClientUtility.cs
+++ b/ArxOne.Ftp/FtpClientUtility.cs
@@ -330,7 +330,7 @@ namespace ArxOne.Ftp
         {
             session.CheckProtection(FtpProtection.ControlChannel);
             var reply = session.SendCommand("STAT", session.Connection.Client.GetPlatform(session).EscapePath(path.ToString()));
-            if ((reply.Code != 213 && reply.Code != 211) || reply.Lines.Length <= 2)
+            if ((reply.Code != 213 && reply.Code != 211 && reply.Code != 212) || reply.Lines.Length <= 2)
                 return null;
             // now get the type: the first entry is "." for folders or file itself for files/links
             var entry = EnumerateEntries(session.Connection.Client, path, reply.Lines.Skip(1), ignoreSpecialEntries: false).First();


### PR DESCRIPTION
I just added 212 (directory status) at line 333 as a valid STAT return code
While editing, GitHub detected mixed line endings so it normalized to CRLF. That explains why most of the file is marked as changed.